### PR TITLE
made rotateViewToCenter as a public method

### DIFF
--- a/circlemenu/src/main/java/com/szugyi/circlemenu/view/CircleLayout.java
+++ b/circlemenu/src/main/java/com/szugyi/circlemenu/view/CircleLayout.java
@@ -345,7 +345,7 @@ public class CircleLayout extends ViewGroup {
      *
      * @param view the view to be rotated
      */
-    private void rotateViewToCenter(View view) {
+    public void rotateViewToCenter(View view) {
         if (isRotating) {
             float viewAngle = view.getTag() != null ? (Float) view.getTag() : 0;
             float destAngle = (firstChildPosition.getAngle() - viewAngle);


### PR DESCRIPTION
This will make the rotataeViewToCenter method to be available as a public method by which we can move any child view to the firstChildPosition